### PR TITLE
Error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freighthub/typed-env",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Enforceable environment variable contracts at runtime",
   "author": "FreightHub GmbH",
   "main": "dist/src/index.js",

--- a/src/loader.spec.ts
+++ b/src/loader.spec.ts
@@ -8,10 +8,10 @@ describe('loader', () => {
         }, 'FOO'),
         baz: loader.envGroup({
             BAZ: types.NonEmptyString,
-        }, '')
+        }, ''),
     })
 
-    describe('LoadFromEnv', () => {
+    describe('#loadFrom', () => {
         it('should fill values from env object', () => {
             const env = loader.loadFrom({
                 FOO_BAR: 'test',
@@ -19,6 +19,25 @@ describe('loader', () => {
             }, schema)
             expect(env.foo.BAR).toEqual('test')
             expect(env.baz.BAZ).toEqual('test2')
+        })
+
+        it('reports errors when envvars are not set', () => {
+            expect(() => loader.loadFrom({ FOO_BAR: 2 }, schema))
+                .toThrowError(`Invalid value 2 supplied to : ENV/foo: FOO/BAR: NonEmptyString\nInvalid value undefined supplied to : ENV/baz: /BAZ: NonEmptyString`)
+        })
+    })
+
+    describe('#loadFromEnv', () => {
+        it('loads ennvars using process.env', () => {
+            const schema = loader.envSchema({
+                node: loader.envGroup({
+                    ENV: types.NonEmptyString,
+                }, 'NODE'),
+            })
+
+            const env = loader.loadFromEnv(schema)
+
+            expect(env).toEqual({ node: { ENV: 'test' } })
         })
     })
 })

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,24 +1,30 @@
 import * as t from 'io-ts'
+import { ThrowReporter } from 'io-ts/lib/ThrowReporter'
 import * as deepFreeze from 'deep-freeze'
 
 export * from 'io-ts'
 
 export interface ExactInterface<P extends t.Props>
-    extends t.ExactType<
-        t.InterfaceType<P, t.TypeOfProps<P>, t.OutputOfProps<P>, t.mixed>,
+    extends t.ExactType<t.InterfaceType<P, t.TypeOfProps<P>, t.OutputOfProps<P>, t.mixed>,
         t.TypeOfProps<P>,
         t.OutputOfProps<P>,
-        t.mixed
-        > {}
+        t.mixed>
+{
+}
 
-export interface EnvGroup<P extends t.Props> extends ExactInterface<P> {}
+export interface EnvGroup<P extends t.Props> extends ExactInterface<P> {
+}
 
 export type EnvGroups = { [key: string]: EnvGroup<any> }
 
 export interface EnvSchema<P extends EnvGroups>
-    extends t.ReadonlyType<ExactInterface<P>, Readonly<t.TypeOfProps<P>>, Readonly<t.OutputOfProps<P>>, t.mixed> {}
+    extends t.ReadonlyType<ExactInterface<P>, Readonly<t.TypeOfProps<P>>, Readonly<t.OutputOfProps<P>>, t.mixed> {
+}
 
-export const envGroup = <P extends t.Props> (props: P, prefix?: string): EnvGroup<P> => t.exact(t.type(props), prefix || '')
+export const envGroup = <P extends t.Props> (
+    props: P,
+    prefix?: string,
+): EnvGroup<P> => t.exact(t.type(props), prefix || '')
 export const envSchema = <P extends EnvGroups> (props: P): EnvSchema<P> => t.readonly(t.exact(t.type(props), 'ENV'), 'ENV')
 
 export type EnvObject = {
@@ -41,7 +47,7 @@ function extractFromEnvObject (prefix: string, props: Array<string>, envObject: 
     }, {})
 }
 
-export function loadFrom<P extends EnvGroups>(envObject: EnvObject, schema: EnvSchema<P>): Readonly<t.TypeOfProps<P>> {
+export function loadFrom<P extends EnvGroups> (envObject: EnvObject, schema: EnvSchema<P>): Readonly<t.TypeOfProps<P>> {
     const schemaProperties = schema.type.type.props
     const envValues = Object.keys(schemaProperties).reduce((envValues: EnvValues, schemaKey: string) => {
         const group = schemaProperties[schemaKey]
@@ -51,9 +57,13 @@ export function loadFrom<P extends EnvGroups>(envObject: EnvObject, schema: EnvS
         return envValues
     }, {})
 
-    return schema.decode(envValues).fold(errors => {
-        throw new Error(errors.join('\n'))
-    }, value => deepFreeze(value))
+    const result = schema.decode(envValues)
+
+    if (result.isLeft()) {
+        throw ThrowReporter.report(result)
+    }
+
+    return deepFreeze(result.value)
 }
 
 export const loadFromEnv = <P extends EnvGroups> (schema: EnvSchema<P>): t.TypeOfProps<P> => loadFrom(process.env, schema)


### PR DESCRIPTION
This fix solves problem with error reporting - instead of getting clear messages what envvars are not set properly, it was showing `[object Object]`.