### PR TITLE
Added standalone npm deploy script to use NPM_TOKEN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
               ssh-keyscan github.com >> ~/.ssh/known_hosts
         - run:
             name: Publish to NPM
-            command: yarn publish:package
+            command: .circleci/deploy.sh
 workflows:
     version: 2
     build_test:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# make sure -x (debugging) is off so we do not print the npm token in the logs
+set +x
+
+if [ -f ~/.npmrc ]; then mv ~/.npmrc ~/.npmrc.bak; fi
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+echo "@freighthub:registry=https://registry.npmjs.org/" >> ~/.npmrc
+
+yarn publish:package
+
+if [ -f ~/.npmrc.bak ]; then mv ~/.npmrc.bak ~/.npmrc; fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-@freighthub:registry=https://registry.npmjs.org/


### PR DESCRIPTION
This PR tries to fix issue #49 
As we require NPM_TOKEN only for publish, added a standalone script to publish the package