### PR TITLE
Add support for loading YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 Use this library to make
 sure all the environment variables used in a project are valid.
 
-
 ## Usage
 
 To use the library, first declare a schema that consists of groups. A group is
@@ -30,9 +29,10 @@ const schema = typedEnv.envSchema({
 ```
 
 In the above example `statsd` group will be used to load variables
- - `STATSD_HOST`
- - `STATSD_PORT`
- - `STATSD_PREFIX`
+
+- `STATSD_HOST`
+- `STATSD_PORT`
+- `STATSD_PREFIX`
 
 The optional `STATSD` prefix is passed as the second parameter to `envGroup`.
 The schema is then created using `envSchema` function that accepts a dictionary
@@ -51,13 +51,13 @@ If any variables are missing or don't pass type checking, an exception will occu
 
 `typed-env` provides the following schema types:
 
-* `Number` - any number
-* `Integer` - integer number
-* `PortNumber` - integer number between 1 and 65535
-* `NonEmptyString` - non-empty string of any length
-* `URI` - URI as checked by valid-url
-* `Boolean` - true or false
-* `Union` - a collection of string literals to resctrict a variable's possible value
+- `Number` - any number
+- `Integer` - integer number
+- `PortNumber` - integer number between 1 and 65535
+- `NonEmptyString` - non-empty string of any length
+- `URI` - URI as checked by valid-url
+- `Boolean` - true or false
+- `Union` - a collection of string literals to resctrict a variable's possible value
 
 ## Example
 
@@ -72,4 +72,19 @@ const schema = typedEnv.envSchema({
 
 const env = typedEnv.loadFromEnv(schema)
 console.log(env.elasticSearch.URL)
+```
+
+## Infrastructure as code
+
+In case you store environment variables in code, e.g. when you are using helm, you can validate your environment variables in your test suite using `loadFromYAMLFiles`:
+
+```typescript
+import * as typedEnv from '@freighthub/typed-env'
+import { schema } from './envSchema'
+
+describe('Environment variables', () => {
+    test('all environment variables are set', () => {
+        typedEnv.loadFromYAMLFiles(['./values.yaml#/env', './secrets.yaml#/env'], schema)
+    })
+})
 ```

--- a/fixtures/yaml1.yaml
+++ b/fixtures/yaml1.yaml
@@ -1,0 +1,2 @@
+env:
+  VALUES_A: "A"

--- a/fixtures/yaml2.yaml
+++ b/fixtures/yaml2.yaml
@@ -1,0 +1,2 @@
+env:
+  VALUES_B: "B"

--- a/package.json
+++ b/package.json
@@ -36,11 +36,15 @@
     "deep-freeze": "^0.0.1",
     "fp-ts": "^2.1.1",
     "io-ts": "^2.0.1",
+    "js-yaml": "^4.0.0",
+    "lodash": "^4.17.21",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {
     "@types/deep-freeze": "^0.1.1",
     "@types/jest": "^26.0.0",
+    "@types/js-yaml": "^4.0.0",
+    "@types/lodash": "^4.14.168",
     "@types/node": "^14.0.0",
     "@types/valid-url": "^1.0.2",
     "jest": "~24.9.0",

--- a/src/EnvObject.ts
+++ b/src/EnvObject.ts
@@ -1,0 +1,4 @@
+
+export type EnvObject = {
+    [key: string]: any
+}

--- a/src/loader.spec.ts
+++ b/src/loader.spec.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as loader from './loader'
 import * as types from './types'
 
@@ -40,4 +41,34 @@ describe('loader', () => {
             expect(env).toEqual({ node: { ENV: 'test' } })
         })
     })
+
+    describe('#loadFromYAMLFiles', () => {
+        it('should load env vars from YAML files', () => {
+            const schema = loader.envSchema({
+                values: loader.envGroup({
+                    A: types.NonEmptyString,
+                    B: types.NonEmptyString
+                }, 'VALUES')
+            })
+
+            const files = [
+                path.resolve(__dirname, '..', 'fixtures', 'yaml1.yaml#/env'),
+                path.resolve(__dirname, '..', 'fixtures', 'yaml2.yaml#/env'),
+            ]
+
+            const env = loader.loadFromYAMLFiles(files, schema)
+
+            expect(env).toEqual({values: {A: 'A', B: 'B'}})
+        });
+        
+        it('should throw an error when env vars are not set', () => {
+            const schema = loader.envSchema({
+                values: loader.envGroup({
+                    A: types.NonEmptyString,
+                })
+            })
+
+            expect(() => loader.loadFromYAMLFiles([], schema)).toThrowError()
+        });
+    });
 })

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -66,4 +66,10 @@ export function loadFrom<P extends EnvGroups> (envObject: EnvObject, schema: Env
 }
 
 export const loadFromEnv = <P extends EnvGroups> (schema: EnvSchema<P>): t.TypeOfProps<P> => loadFrom(process.env, schema)
+/**
+ * Load the environment from YAML files.
+ * @param yamlFilePaths Paths of YAML files to load. The paths support a simplified version of JSONPath, e.g. (./values.yaml#/service/env). Multiple files will be merged in sequence, the last overriding the first.
+ * @param schema The EnvGroups schema
+ * @returns EnvGroups
+ */
 export const loadFromYAMLFiles = <P extends EnvGroups>(yamlFilePaths: string[], schema: EnvSchema<P>) => loadFrom(envFromYAMLFiles(yamlFilePaths), schema)

--- a/src/yaml.spec.ts
+++ b/src/yaml.spec.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import { envFromYAMLFiles, valueAt } from './yaml';
+
+describe('yaml', () => {
+    describe('#valueAt', () => {
+        const testObject = { a: { b: 'c' } }
+
+        it.each`
+            path | expected
+            ${"#/"} | ${testObject}
+            ${"#/a"} | ${testObject.a}
+            ${"#/a/b"} | ${testObject.a.b}
+        `(
+            'should resolve path $path to $expected',
+            ({ path, expected }) => {
+                expect(valueAt(testObject, path)).toEqual(expected);
+            }
+        );
+    });
+
+    describe('#envFromYAMLFiles', () => {
+        it('should be an empty object if no files are passed', () => {
+            expect(envFromYAMLFiles([])).toEqual({})
+        });
+
+        it('should load a single yaml file', () => {
+            expect(envFromYAMLFiles([
+                path.resolve(__dirname, '..', 'fixtures', 'yaml1.yaml#/env')
+            ])).toEqual({ VALUES_A: "A" })
+        });
+
+        it('should load multiple yaml files', () => {
+            expect(envFromYAMLFiles([
+                path.resolve(__dirname, '..', 'fixtures', 'yaml1.yaml#/env'), 
+                path.resolve(__dirname, '..', 'fixtures', 'yaml2.yaml#/env')
+            ])).toEqual({ VALUES_A: "A", VALUES_B: "B" })
+        });
+    });
+});

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,0 +1,32 @@
+import { get, merge } from 'lodash'
+import { readFileSync } from 'fs'
+import { load as parseYAML } from 'js-yaml'
+import { EnvObject } from './EnvObject'
+
+export function valueAt(obj: any, jsonPath: string) {
+    const dotPath = dotNotationFrom(jsonPath)
+    return dotPath === '' ? obj : get(obj, dotPath)
+}
+
+function dotNotationFrom(jsonPath: string) {
+    return jsonPath.replace(/^#\//,'').replace(/\//g, '.')
+}
+
+function envFromYAMLFile(filePathWithEnvJSONPath: string) {
+    const [filePath, envJSONPathWithoutHashtag = '/'] = filePathWithEnvJSONPath.split('#')
+    const content = readYAMLFileSync(filePath)
+    const env = valueAt(content, `#${envJSONPathWithoutHashtag}`)
+    return env
+}
+
+function readYAMLFileSync(filePath: string) {
+    const fileContent = readFileSync(filePath).toString()
+    const parsedContent = parseYAML(fileContent)
+    return parsedContent
+}
+
+export function envFromYAMLFiles(valueFilePaths: string[]): EnvObject {
+    const envs = valueFilePaths.map(envFromYAMLFile)
+    const env = envs.reduce(merge, {})
+    return env
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,6 +388,16 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/js-yaml@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz#d1a11688112091f2c711674df3a65ea2f47b5dfb"
+  integrity sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==
+
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/node@*", "@types/node@^14.0.0":
   version "14.14.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
@@ -543,6 +553,11 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2403,6 +2418,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -2562,6 +2584,11 @@ lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
What?
Support loading env from YAML files.

```typescript
import * as typedEnv from '@freighthub/typed-env'
import { schema } from './envSchema'

describe('Environment variables', () => {
    test('all environment variables are set', () => {
        typedEnv.loadFromYAMLFiles(['./values.yaml#/env', './secrets.yaml#/env'], schema)
    })
})
```

Why?
In case you store environment variables in code, e.g. when you are using helm, you can validate your environment variables in your test suite to prevent failing application starts because of missing environment variables.